### PR TITLE
Use ros msg

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,6 +15,7 @@ if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
 endif()
 
 find_package(ament_cmake REQUIRED)
+find_package(argparse REQUIRED)
 find_package(keisan REQUIRED)
 find_package(musen REQUIRED)
 find_package(rclcpp REQUIRED)
@@ -28,7 +29,7 @@ target_include_directories(${PROJECT_NAME} PUBLIC
   $<INSTALL_INTERFACE:include>)
 
 ament_target_dependencies(${PROJECT_NAME}
-  keisan musen rclcpp tosshin_cpp)
+  argparse keisan musen rclcpp tosshin_cpp)
 
 install(DIRECTORY "include" DESTINATION ".")
 
@@ -54,7 +55,7 @@ if(BUILD_TESTING)
   ament_lint_auto_find_test_dependencies()
 endif()
 
-ament_export_dependencies(keisan musen rclcpp tosshin_cpp)
+ament_export_dependencies(argparse keisan musen rclcpp tosshin_cpp)
 ament_export_include_directories("include")
 ament_export_libraries(${PROJECT_NAME})
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,7 +22,7 @@ find_package(musen REQUIRED)
 find_package(nav_msgs REQUIRED)
 find_package(rclcpp REQUIRED)
 find_package(tf2 REQUIRED)
-find_package(tosshin_cpp REQUIRED)
+find_package(tf2_geometry_msgs REQUIRED)
 
 install(DIRECTORY "include" DESTINATION ".")
 
@@ -34,7 +34,7 @@ target_include_directories(${PROJECT_NAME} PUBLIC
   $<INSTALL_INTERFACE:include>)
 
 ament_target_dependencies(${PROJECT_NAME}
-  argparse geometry_msgs keisan musen nav_msgs rclcpp tf2 tosshin_cpp)
+  argparse geometry_msgs keisan musen nav_msgs rclcpp tf2 tf2_geometry_msgs)
 
 install(TARGETS ${PROJECT_NAME}
   EXPORT export_${PROJECT_NAME}
@@ -59,7 +59,7 @@ if(BUILD_TESTING)
 endif()
 
 ament_export_dependencies(
-  argparse geometry_msgs keisan musen nav_msgs rclcpp tf2 tosshin_cpp)
+  argparse geometry_msgs keisan musen nav_msgs rclcpp tf2 tf2_geometry_msgs)
 
 ament_export_include_directories("include")
 ament_export_libraries(${PROJECT_NAME})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,14 +15,13 @@ if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
 endif()
 
 find_package(ament_cmake REQUIRED)
-find_package(argparse REQUIRED)
-find_package(geometry_msgs REQUIRED)
-find_package(keisan REQUIRED)
-find_package(musen REQUIRED)
-find_package(nav_msgs REQUIRED)
-find_package(rclcpp REQUIRED)
-find_package(tf2 REQUIRED)
-find_package(tf2_geometry_msgs REQUIRED)
+
+set(DEPENDENCIES
+  argparse geometry_msgs musen nav_msgs rclcpp tf2 tf2_geometry_msgs)
+
+foreach(DEPENDENCY ${DEPENDENCIES})
+  find_package(${DEPENDENCY} REQUIRED)
+endforeach()
 
 install(DIRECTORY "include" DESTINATION ".")
 
@@ -33,8 +32,7 @@ target_include_directories(${PROJECT_NAME} PUBLIC
   $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
   $<INSTALL_INTERFACE:include>)
 
-ament_target_dependencies(${PROJECT_NAME}
-  argparse geometry_msgs keisan musen nav_msgs rclcpp tf2 tf2_geometry_msgs)
+ament_target_dependencies(${PROJECT_NAME} ${DEPENDENCIES})
 
 install(TARGETS ${PROJECT_NAME}
   EXPORT export_${PROJECT_NAME}
@@ -58,9 +56,7 @@ if(BUILD_TESTING)
   ament_lint_auto_find_test_dependencies()
 endif()
 
-ament_export_dependencies(
-  argparse geometry_msgs keisan musen nav_msgs rclcpp tf2 tf2_geometry_msgs)
-
+ament_export_dependencies(${DEPENDENCIES})
 ament_export_include_directories("include")
 ament_export_libraries(${PROJECT_NAME})
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,10 +16,15 @@ endif()
 
 find_package(ament_cmake REQUIRED)
 find_package(argparse REQUIRED)
+find_package(geometry_msgs REQUIRED)
 find_package(keisan REQUIRED)
 find_package(musen REQUIRED)
+find_package(nav_msgs REQUIRED)
 find_package(rclcpp REQUIRED)
+find_package(tf2 REQUIRED)
 find_package(tosshin_cpp REQUIRED)
+
+install(DIRECTORY "include" DESTINATION ".")
 
 add_library(${PROJECT_NAME}
   "src/navigation.cpp")
@@ -29,9 +34,7 @@ target_include_directories(${PROJECT_NAME} PUBLIC
   $<INSTALL_INTERFACE:include>)
 
 ament_target_dependencies(${PROJECT_NAME}
-  argparse keisan musen rclcpp tosshin_cpp)
-
-install(DIRECTORY "include" DESTINATION ".")
+  argparse geometry_msgs keisan musen nav_msgs rclcpp tf2 tosshin_cpp)
 
 install(TARGETS ${PROJECT_NAME}
   EXPORT export_${PROJECT_NAME}
@@ -55,7 +58,9 @@ if(BUILD_TESTING)
   ament_lint_auto_find_test_dependencies()
 endif()
 
-ament_export_dependencies(argparse keisan musen rclcpp tosshin_cpp)
+ament_export_dependencies(
+  argparse geometry_msgs keisan musen nav_msgs rclcpp tf2 tosshin_cpp)
+
 ament_export_include_directories("include")
 ament_export_libraries(${PROJECT_NAME})
 

--- a/bin/navigation.cpp
+++ b/bin/navigation.cpp
@@ -61,7 +61,7 @@ int main(int argc, char ** argv)
   auto navigation = std::make_shared<dienen_controller::Navigation>(navigation_options);
 
   if (navigation->connect()) {
-    rclcpp::spin(navigation->get_node());
+    rclcpp::spin(navigation);
   } else {
     std::cerr << "Failed to initialize the connection!" << std::endl;
   }

--- a/bin/navigation.cpp
+++ b/bin/navigation.cpp
@@ -33,17 +33,22 @@ int main(int argc, char ** argv)
   dienen_controller::Navigation::Options navigation_options;
 
   program.add_argument("target_host")
-  .help("Target controller's host IP");
+  .help("target host IP of the controller");
 
   program.add_argument("--listen-port", "-l")
-  .help("Listen port from the target controller")
+  .help("listen port to be used")
   .default_value(navigation_options.listen_port)
   .action([](const std::string & value) {return std::stoi(value);});
 
   program.add_argument("--broadcast-port", "-b")
-  .help("Broadcast port to the target controller")
+  .help("broadcast port to be used")
   .default_value(navigation_options.broadcast_port)
   .action([](const std::string & value) {return std::stoi(value);});
+
+  program.add_argument("--position-from-twist")
+  .help("obtains position from twist movement calculation")
+  .default_value(false)
+  .implicit_value(true);
 
   try {
     program.parse_args(argc, argv);
@@ -51,6 +56,7 @@ int main(int argc, char ** argv)
     navigation_options.target_host = program.get<std::string>("target_host");
     navigation_options.listen_port = program.get<int>("--listen-port");
     navigation_options.broadcast_port = program.get<int>("--broadcast-port");
+    navigation_options.position_from_twist = program.get<bool>("--position-from-twist");
   } catch (const std::exception & e) {
     std::cout << e.what() << std::endl << program;
     return 1;

--- a/bin/navigation.cpp
+++ b/bin/navigation.cpp
@@ -23,31 +23,34 @@
 
 #include <memory>
 #include <string>
+#include <vector>
 
 int main(int argc, char ** argv)
 {
-  rclcpp::init(argc, argv);
+  dienen_controller::Navigation::Options options;
 
-  auto node = std::make_shared<rclcpp::Node>("navigation");
-
-  std::shared_ptr<dienen_controller::Navigation> navigation;
-  if (argc > 3) {
-    navigation = std::make_shared<dienen_controller::Navigation>(
-      node, std::string(argv[1]), atoi(argv[2]), atoi(argv[3]));
-  } else if (argc > 2) {
-    navigation = std::make_shared<dienen_controller::Navigation>(
-      node, std::string(argv[1]), atoi(argv[2]));
-  } else if (argc > 1) {
-    navigation = std::make_shared<dienen_controller::Navigation>(
-      node, std::string(argv[1]));
-  } else {
+  if (argc < 2) {
     std::cerr << "Usage: ros2 run dienen_controller navigation " <<
       "<target_host> [listen_port] [broadcast_port]" << std::endl;
     return 1;
+  } else {
+    options.target_host = argv[1];
+
+    if (argc > 2) {
+      options.listen_port = atoi(argv[2]);
+    }
+
+    if (argc > 3) {
+      options.broadcast_port = atoi(argv[3]);
+    }
   }
 
+  rclcpp::init(argc, argv);
+
+  auto navigation = std::make_shared<dienen_controller::Navigation>(options);
+
   if (navigation->connect()) {
-    rclcpp::spin(node);
+    rclcpp::spin(navigation->get_node());
   } else {
     std::cerr << "Failed to initialize the connection!" << std::endl;
   }

--- a/include/dienen_controller/navigation.hpp
+++ b/include/dienen_controller/navigation.hpp
@@ -26,7 +26,6 @@
 #include <musen/musen.hpp>
 #include <nav_msgs/msg/odometry.hpp>
 #include <rclcpp/rclcpp.hpp>
-#include <tosshin_cpp/tosshin_cpp.hpp>
 
 #include <memory>
 #include <string>

--- a/include/dienen_controller/navigation.hpp
+++ b/include/dienen_controller/navigation.hpp
@@ -21,7 +21,10 @@
 #ifndef DIENEN_CONTROLLER__NAVIGATION_HPP_
 #define DIENEN_CONTROLLER__NAVIGATION_HPP_
 
+#include <geometry_msgs/msg/pose.hpp>
+#include <geometry_msgs/msg/twist.hpp>
 #include <musen/musen.hpp>
+#include <nav_msgs/msg/odometry.hpp>
 #include <rclcpp/rclcpp.hpp>
 #include <tosshin_cpp/tosshin_cpp.hpp>
 
@@ -31,7 +34,11 @@
 namespace dienen_controller
 {
 
-class Navigation : public tosshin_cpp::NavigationProvider
+using geometry_msgs::msg::Pose;
+using geometry_msgs::msg::Twist;
+using nav_msgs::msg::Odometry;
+
+class Navigation : public rclcpp::Node
 {
 public:
   struct Options : public rclcpp::NodeOptions
@@ -69,9 +76,13 @@ private:
   void listen_process();
   void broadcast_process();
 
-  std::shared_ptr<tosshin_cpp::NavigationProvider> navigation_provider;
+  rclcpp::Subscription<Twist>::SharedPtr twist_subscription;
+  rclcpp::Publisher<Odometry>::SharedPtr odometry_publisher;
 
   rclcpp::TimerBase::SharedPtr update_timer;
+
+  Pose current_pose;
+  Twist current_twist;
 
   std::shared_ptr<musen::Listener> listener;
   std::shared_ptr<musen::Broadcaster> broadcaster;

--- a/include/dienen_controller/navigation.hpp
+++ b/include/dienen_controller/navigation.hpp
@@ -34,6 +34,16 @@ namespace dienen_controller
 class Navigation : public tosshin_cpp::NavigationProvider
 {
 public:
+  struct Options : public rclcpp::NodeOptions
+  {
+    Options();
+
+    std::string node_name;
+    std::string target_host;
+    int listen_port;
+    int broadcast_port;
+  };
+
   struct BroadcastMessage
   {
     char headers[3] = {'i', 't', 's'};
@@ -49,10 +59,7 @@ public:
     float x_offset;
   } __attribute__((packed, aligned(1)));
 
-  Navigation(
-    rclcpp::Node::SharedPtr node, std::string target_host,
-    int listen_port = 8888, int broadcast_port = 44444);
-
+  explicit Navigation(const Options & options = Options());
   ~Navigation();
 
   bool connect();

--- a/include/dienen_controller/navigation.hpp
+++ b/include/dienen_controller/navigation.hpp
@@ -28,6 +28,7 @@
 #include <rclcpp/rclcpp.hpp>
 
 #include <memory>
+#include <optional>  // NOLINT
 #include <string>
 
 namespace dienen_controller
@@ -79,6 +80,8 @@ private:
   rclcpp::Publisher<Odometry>::SharedPtr odometry_publisher;
 
   rclcpp::TimerBase::SharedPtr update_timer;
+
+  std::optional<double> initial_yaw;
 
   Pose current_pose;
   Twist current_twist;

--- a/include/dienen_controller/navigation.hpp
+++ b/include/dienen_controller/navigation.hpp
@@ -47,8 +47,11 @@ public:
 
     std::string node_name;
     std::string target_host;
+
     int listen_port;
     int broadcast_port;
+
+    bool position_from_twist;
   };
 
   struct BroadcastMessage
@@ -75,6 +78,8 @@ public:
 private:
   void listen_process();
   void broadcast_process();
+
+  Options options;
 
   rclcpp::Subscription<Twist>::SharedPtr twist_subscription;
   rclcpp::Publisher<Odometry>::SharedPtr odometry_publisher;

--- a/package.xml
+++ b/package.xml
@@ -15,7 +15,7 @@
   <depend>nav_msgs</depend>
   <depend>rclcpp</depend>
   <depend>tf2</depend>
-  <depend>tosshin_cpp</depend>
+  <depend>tf2_geometry_msgs</depend>
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>
   <export>

--- a/package.xml
+++ b/package.xml
@@ -8,10 +8,13 @@
   <license>MIT License</license>
   <url>https://github.com/threeal/dienen_controller</url>
   <buildtool_depend>ament_cmake</buildtool_depend>
-  <depend>libargparse-dev</depend>
+  <depend>geometry_msgs</depend>
   <depend>keisan</depend>
+  <depend>libargparse-dev</depend>
   <depend>musen</depend>
+  <depend>nav_msgs</depend>
   <depend>rclcpp</depend>
+  <depend>tf2</depend>
   <depend>tosshin_cpp</depend>
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>

--- a/package.xml
+++ b/package.xml
@@ -9,7 +9,6 @@
   <url>https://github.com/threeal/dienen_controller</url>
   <buildtool_depend>ament_cmake</buildtool_depend>
   <depend>geometry_msgs</depend>
-  <depend>keisan</depend>
   <depend>libargparse-dev</depend>
   <depend>musen</depend>
   <depend>nav_msgs</depend>

--- a/package.xml
+++ b/package.xml
@@ -8,6 +8,7 @@
   <license>MIT License</license>
   <url>https://github.com/threeal/dienen_controller</url>
   <buildtool_depend>ament_cmake</buildtool_depend>
+  <depend>libargparse-dev</depend>
   <depend>keisan</depend>
   <depend>musen</depend>
   <depend>rclcpp</depend>

--- a/src/navigation.cpp
+++ b/src/navigation.cpp
@@ -134,7 +134,7 @@ void Navigation::listen_process()
       auto yaw = keisan::deg_to_rad(stod(message[2]));
 
       tf2::Quaternion orientation;
-      orientation.setEuler(yaw, 0.0, 0.0);
+      orientation.setRPY(0.0, 0.0, yaw);
 
       current_pose.orientation.x = orientation.x();
       current_pose.orientation.y = orientation.y();

--- a/src/navigation.cpp
+++ b/src/navigation.cpp
@@ -133,13 +133,17 @@ void Navigation::listen_process()
       // Orientation received as yaw in degree
       auto yaw = keisan::deg_to_rad(stod(message[2]));
 
+      // Shift yaw from the initial yaw
+      if (initial_yaw.has_value()) {
+        yaw -= initial_yaw.value();
+      } else {
+        initial_yaw = std::make_optional<double>(yaw);
+      }
+
       tf2::Quaternion orientation;
       orientation.setRPY(0.0, 0.0, yaw);
 
-      current_pose.orientation.x = orientation.x();
-      current_pose.orientation.y = orientation.y();
-      current_pose.orientation.z = orientation.z();
-      current_pose.orientation.w = orientation.w();
+      tf2::convert(orientation, current_pose.orientation);
 
       // Calculate pose from the maneuver instead
       {

--- a/src/navigation.cpp
+++ b/src/navigation.cpp
@@ -34,10 +34,16 @@ namespace dienen_controller
 
 using namespace std::chrono_literals;
 
-Navigation::Navigation(
-  rclcpp::Node::SharedPtr node, std::string target_host,
-  int listen_port, int broadcast_port)
-: tosshin_cpp::NavigationProvider(node)
+Navigation::Options::Options()
+: node_name("navigation"),
+  target_host("169.254.183.100"),
+  listen_port(8888),
+  broadcast_port(44444)
+{
+}
+
+Navigation::Navigation(const Options & options)
+: tosshin_cpp::NavigationProvider(std::make_shared<rclcpp::Node>(options.node_name, options))
 {
   // Initialize the update timer
   {
@@ -52,7 +58,7 @@ Navigation::Navigation(
 
   // Initialize the listener
   {
-    listener = std::make_shared<musen::Listener>(listen_port);
+    listener = std::make_shared<musen::Listener>(options.listen_port);
 
     RCLCPP_INFO_STREAM(
       get_node()->get_logger(),
@@ -61,9 +67,10 @@ Navigation::Navigation(
 
   // Initialize the broadcaster
   {
-    broadcaster = std::make_shared<musen::Broadcaster>(broadcast_port, listener->get_udp_socket());
+    broadcaster = std::make_shared<musen::Broadcaster>(
+      options.broadcast_port, listener->get_udp_socket());
 
-    broadcaster->add_target_host(target_host);
+    broadcaster->add_target_host(options.target_host);
     broadcaster->enable_broadcast(false);
 
     RCLCPP_INFO_STREAM(

--- a/src/navigation.cpp
+++ b/src/navigation.cpp
@@ -18,9 +18,8 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-#include <keisan/keisan.hpp>
-
 #include <dienen_controller/navigation.hpp>
+#include <keisan/keisan.hpp>
 
 #include <sys/socket.h>
 #include <unistd.h>

--- a/src/navigation.cpp
+++ b/src/navigation.cpp
@@ -19,7 +19,6 @@
 // THE SOFTWARE.
 
 #include <dienen_controller/navigation.hpp>
-#include <keisan/keisan.hpp>
 #include <tf2/utils.h>
 
 #include <sys/socket.h>
@@ -131,7 +130,7 @@ void Navigation::listen_process()
       // odometry.position.x = stod(message[1]) * 0.01;
 
       // Orientation received as yaw in degree
-      auto yaw = keisan::deg_to_rad(stod(message[2]));
+      auto yaw = tf2Radians(stod(message[2]));
 
       // Shift yaw from the initial yaw
       if (initial_yaw.has_value()) {
@@ -141,7 +140,7 @@ void Navigation::listen_process()
       }
 
       tf2::Quaternion orientation;
-      orientation.setRPY(0.0, 0.0, yaw);
+      orientation.setRPY(0.0, 0.0, tf2NormalizeAngle(yaw));
 
       tf2::convert(orientation, current_pose.orientation);
 


### PR DESCRIPTION
- Add options for the `Navigation` class.
- Use [argparse](https://github.com/p-ranav/argparse) to parse arguments.
- Replace [tosshin_cpp](https://github.com/threeal/tosshin) with a standard ROS 2 msgs.
- Replace functions from [keisan](https://github.com/ichiro-its/keisan) with [TF2](https://github.com/ros2/geometry2).
- Reset yaw orientation during executable initialization.
- Add an optional argument to obtain position twist calculation instead from the controller.